### PR TITLE
update in README.md for installing tkinter

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ venv\bin\activate.bat
 
 # install required packages
 
+## Linux
+test if you have tkinter in your system
+
+```bash
+$ python -m tkinter
+```
+
+If you don't see a new window, you need to install tkinter
+(Ubuntu example)
+```bash
+$ sudo apt-get update && sudo apt-get install python3-tk
+```
+
+
 ## update the environment
 pip install -U pip
 pip install -U setuptools wheel


### PR DESCRIPTION
Hello, 
I was trying to install your package, but it appears that there are some missing dependencies.
Following your instructions lead to an error
```bash
(REDigest) $ python REDigestGUI.py 
Traceback (most recent call last):
  File "/home/javier/REDigest/REDigestGUI.py", line 20, in <module>
    import tkinter as tk
ModuleNotFoundError: No module named 'tkinter'
```

installing with pip does not fix the error
```bash
(REDIgest) $ pip install tk
Collecting tk
  Downloading tk-0.1.0-py3-none-any.whl (3.9 kB)
Installing collected packages: tk
Successfully installed tk-0.1.0
(REDigest) $ python REDigestGUI.py 
Traceback (most recent call last):
  File "/home/javier/REDigest/REDigestGUI.py", line 20, in <module>
    import tkinter as tk
ModuleNotFoundError: No module named 'tkinter'
```
However, installing with system-wide option does the trick
```bash
~/REDigest$ sudo apt-get install python3-tk
```

I updated README.md so it reflects this issue